### PR TITLE
fix: Print resolved value from promise in console.log instead of console.error

### DIFF
--- a/ch-8/labs-2/serial.js
+++ b/ch-8/labs-2/serial.js
@@ -29,9 +29,9 @@ const b = promisify(opB)
 const c = promisify(opC)
 
 async function main () {
-  print(await a())
-  print(await b())
-  print(await c())
+  print(null,await a())
+  print(null,await b())
+  print(null,await c())
 }
 
 main()


### PR DESCRIPTION
The print function is defined to accept two parameters (err, contents), where the first parameter represents an error and the second is the content to be printed. However, when calling print(await a()), the resolved value from the promise is passed as the first argument. This causes the function to mistakenly treat the valid result as an error.